### PR TITLE
Update use-editor.mdx to reflect change from EditorRoot to EditorContent

### DIFF
--- a/apps/docs/components/utils/use-editor.mdx
+++ b/apps/docs/components/utils/use-editor.mdx
@@ -3,7 +3,7 @@ title: "useEditor"
 description: "Imperative API for interacting with the editor."
 ---
 
-Your component must be a child of `EditorRoot` to use this hook.
+Your component must be a child of `EditorContent` to use this hook.
 
 ```tsx
 const CustomComponent = ({ open, onOpenChange }: LinkSelectorProps) => {
@@ -11,9 +11,9 @@ const CustomComponent = ({ open, onOpenChange }: LinkSelectorProps) => {
 ...
 }
 
-<EditorRoot>
+<EditorContent>
   <CustomComponent/>
-</EditorRoot>
+</EditorContent>
 ```
 
 ## Props


### PR DESCRIPTION
To use the `useEditor` hook that exposes tiptap's useCurrentEditor, your child component needs to be a child of EditorContent.